### PR TITLE
修复编辑源码状态下，`.focus()`和`.blur()`失效的问题

### DIFF
--- a/_src/plugins/source.js
+++ b/_src/plugins/source.js
@@ -45,6 +45,12 @@
           holder.onresize = null;
           textarea = null;
           holder = null;
+        },
+        focus: function (){
+          textarea.focus();
+        },
+        blur: function (){
+          textarea.blur();
         }
       };
     },
@@ -78,6 +84,15 @@
           holder.removeChild(dom);
           dom = null;
           codeEditor = null;
+        },
+        focus: function (){
+          codeEditor.focus();
+        },
+        blur: function (){
+          // codeEditor.blur();
+          // since codemirror not support blur()
+          codeEditor.setOption('readOnly', true);
+          codeEditor.setOption('readOnly', false);
         }
       };
     }
@@ -89,6 +104,8 @@
     var sourceMode = false;
     var sourceEditor;
     var orgSetContent;
+    var orgFocus;
+    var orgBlur;
     opt.sourceEditor = browser.ie
       ? "textarea"
       : opt.sourceEditor || "codemirror";
@@ -201,6 +218,18 @@
               "<p>" + (browser.ie ? "" : "<br/>") + "</p>"
             );
           };
+
+          orgFocus = me.focus;
+          orgBlur = me.blur;
+
+          me.focus = function(){
+            sourceEditor.focus();
+          };
+
+          me.blur = function(){
+            orgBlur.call(me);
+            sourceEditor.blur();
+          };
         } else {
           me.iframe.style.cssText = bakCssText;
           var cont =
@@ -224,6 +253,10 @@
           sourceEditor = null;
           //还原getContent方法
           me.getContent = oldGetContent;
+
+          me.focus = orgFocus;
+          me.blur = orgBlur;
+
           var first = me.body.firstChild;
           //trace:1106 都删除空了，下边会报错，所以补充一个p占位
           if (!first) {


### PR DESCRIPTION
## 问题
编缉源码状态下，`.blur()` 方法无法使编辑器失去焦点；`.focus()` 方法不但无法使编缉器获得焦点，还会使编辑器无法接收键盘操作。

## 解决
修改 source 插件，使用与 `.getContent()` 和 `.setContent()` 相同的处理方式，在开启源码编辑模式时对编辑器的 `.focus()` 和 `.blur()` 方法进行覆盖，并在关闭源码编辑模式时还原。